### PR TITLE
fix: resolver error ECONNREFUSED en comunicación Docker entre fronten…

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,7 +53,10 @@ services:
     restart: unless-stopped
     environment:
       # Variables de entorno para Next.js en desarrollo
+      # NEXT_PUBLIC_API_URL: URL que usa el navegador (cliente)
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+      # INTERNAL_API_URL: URL que usa Next.js internamente (server-side)
+      - INTERNAL_API_URL=http://backend:8000
       - NODE_ENV=development
       - PORT=4200
       - HOSTNAME=0.0.0.0

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -54,7 +54,11 @@ const nextConfig = {
 
   // Rewrites para proxy al backend (opcional, útil para desarrollo)
   async rewrites() {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+    // Usar INTERNAL_API_URL si está disponible (dentro de Docker)
+    // Si no, usar NEXT_PUBLIC_API_URL (desarrollo local)
+    const apiUrl = process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+    
+    console.log('🔗 Next.js rewrites configurado para:', apiUrl);
     
     return [
       {

--- a/instructions.md
+++ b/instructions.md
@@ -107,7 +107,6 @@ Siempre responde y pregunta en español
 Pytest para python unit testing
 pytest-asyncio para probar rutas FastAPI (async)
 Jest + React Testing Library para unit testing de React
-Vitest como alternativa moderna a Jest
 Testing Library para testear componentes React
 Cypress para end-to-end testing en el navegador
 


### PR DESCRIPTION
…d y backend

- Agregar variable INTERNAL_API_URL=http://backend:8000 en docker-compose.dev.yml
- Modificar next.config.mjs para usar INTERNAL_API_URL en rewrites SSR
- Separar URLs: NEXT_PUBLIC_API_URL (cliente) vs INTERNAL_API_URL (servidor)
- Agregar log para debugging de configuración de rewrites
- Soluciona error 'Failed to proxy http://localhost:8000/health ECONNREFUSED'

El problema ocurría porque localhost dentro de un contenedor Docker se refiere al propio contenedor, no a otros servicios. La solución usa el nombre del servicio Docker 'backend' para comunicación interna.