### PR TITLE
feat: Agregar carousel de imágenes y endpoint /con-imagenes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,6 +60,25 @@ PLANTNET_API_URL="https://my-api.plantnet.org/v2/identify"
 PLANTNET_PROJECT="all"
 PLANTNET_MAX_REQUESTS_PER_DAY=500
 
+# ==================== Azure Blob Storage ====================
+# IMPORTANTE: Configura las credenciales de tu cuenta de Azure Storage
+# 
+# Opción 1: Usar Connection String (RECOMENDADO - más fácil)
+# Ve a Azure Portal → Storage Account → Access keys → Connection string
+AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=YOUR_ACCOUNT_NAME;AccountKey=YOUR_ACCOUNT_KEY;EndpointSuffix=core.windows.net"
+
+# Opción 2: Usar Account Name + Key por separado (Alternativa)
+# Descomenta estas líneas si prefieres usar esta opción en lugar del Connection String
+# AZURE_STORAGE_ACCOUNT_NAME="your-storage-account-name"
+# AZURE_STORAGE_ACCOUNT_KEY="your-storage-account-key"
+
+# Nombre del container donde se guardarán las imágenes
+AZURE_STORAGE_CONTAINER_NAME="plantitas-imagenes"
+
+# Usar emulador de Azure (Azurite) para desarrollo local
+# Cambia a 'true' si quieres usar Azurite en lugar de Azure real
+AZURE_STORAGE_USE_EMULATOR=false
+
 # Azure OpenAI (Sprint 3)
 AZURE_OPENAI_API_KEY=""
 AZURE_OPENAI_ENDPOINT=""

--- a/backend/app/schemas/planta.py
+++ b/backend/app/schemas/planta.py
@@ -10,7 +10,7 @@ Sprint: Sprint 2 - T-014
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -311,6 +311,143 @@ class PlantaListResponse(BaseModel):
         ...,
         description="Número total de plantas",
         ge=0
+    )
+    
+    class Config:
+        """Configuración del schema."""
+        from_attributes = True
+
+
+class ImagenIdentificacionSchema(BaseModel):
+    """
+    Schema para información básica de una imagen en una identificación.
+    """
+    id: int = Field(
+        ...,
+        description="ID único de la imagen"
+    )
+    nombre_archivo: str = Field(
+        ...,
+        description="Nombre del archivo de imagen"
+    )
+    url_blob: str = Field(
+        ...,
+        description="URL del blob en Azure Storage"
+    )
+    organ: Optional[str] = Field(
+        None,
+        description="Órgano de la planta (flower, leaf, fruit, etc.)"
+    )
+    tamano_bytes: int = Field(
+        ...,
+        description="Tamaño del archivo en bytes"
+    )
+    
+    class Config:
+        """Configuración del schema."""
+        from_attributes = True
+
+
+class EspecieBasicSchema(BaseModel):
+    """
+    Schema para información básica de una especie.
+    """
+    id: int = Field(
+        ...,
+        description="ID único de la especie"
+    )
+    nombre_cientifico: str = Field(
+        ...,
+        description="Nombre científico de la especie"
+    )
+    nombre_comun: Optional[str] = Field(
+        None,
+        description="Nombre común de la especie"
+    )
+    familia: Optional[str] = Field(
+        None,
+        description="Familia taxonómica"
+    )
+    
+    class Config:
+        """Configuración del schema."""
+        from_attributes = True
+
+
+class PlantaUsuarioResponse(BaseModel):
+    """
+    Schema para la respuesta de una planta del usuario con información completa.
+    
+    Incluye:
+    - Todos los datos de la planta
+    - Información de la especie (si está identificada)
+    - Imagen principal
+    - TODAS las imágenes de identificación (si fue agregada desde identificación)
+    """
+    id: int = Field(
+        ...,
+        description="ID único de la planta"
+    )
+    usuario_id: int = Field(
+        ...,
+        description="ID del usuario propietario"
+    )
+    especie_id: Optional[int] = Field(
+        None,
+        description="ID de la especie"
+    )
+    nombre_personalizado: Optional[str] = Field(
+        None,
+        description="Nombre personalizado de la planta"
+    )
+    fecha_adquisicion: Optional[datetime] = Field(
+        None,
+        description="Fecha de adquisición"
+    )
+    ubicacion: Optional[str] = Field(
+        None,
+        description="Ubicación física"
+    )
+    estado_salud: str = Field(
+        ...,
+        description="Estado de salud"
+    )
+    frecuencia_riego_dias: Optional[int] = Field(
+        None,
+        description="Frecuencia de riego en días"
+    )
+    notas: Optional[str] = Field(
+        None,
+        description="Notas del usuario"
+    )
+    imagen_principal_id: Optional[int] = Field(
+        None,
+        description="ID de la imagen principal"
+    )
+    activa: bool = Field(
+        default=True,
+        description="Si la planta está activa"
+    )
+    fecha_creacion: datetime = Field(
+        ...,
+        description="Fecha de creación"
+    )
+    fecha_actualizacion: datetime = Field(
+        ...,
+        description="Fecha de última actualización"
+    )
+    # Información adicional
+    especie: Optional[EspecieBasicSchema] = Field(
+        None,
+        description="Información de la especie"
+    )
+    imagen_principal: Optional[ImagenIdentificacionSchema] = Field(
+        None,
+        description="Imagen principal de la planta"
+    )
+    imagenes_identificacion: List[ImagenIdentificacionSchema] = Field(
+        default_factory=list,
+        description="Todas las imágenes usadas para identificar esta planta"
     )
     
     class Config:

--- a/backend/run.py
+++ b/backend/run.py
@@ -24,6 +24,14 @@ try:
         print("Para detener el servidor, presiona Ctrl+C")
         print("-" * 50)
         
+        # Corregir URLs de Azurite antes de iniciar el servidor
+        print("\n🔧 Corrigiendo URLs de Azurite...")
+        try:
+            from fix_azurite_on_startup import fix_azurite_urls
+            fix_azurite_urls()
+        except Exception as e:
+            print(f"⚠️  No se pudo ejecutar corrección de URLs: {e}")
+        
         # Importar después de configurar el path
         from app.main import app
         

--- a/frontend/lib/plant.service.ts
+++ b/frontend/lib/plant.service.ts
@@ -419,7 +419,8 @@ class PlantService {
    */
   async obtenerMisPlantas(): Promise<PlantaUsuario[]> {
     try {
-      const response = await axios.get<PlantaUsuario[]>('/api/plantas');
+      // Usar el nuevo endpoint que incluye imágenes de identificación
+      const response = await axios.get<PlantaUsuario[]>('/api/plantas/con-imagenes');
       return response.data;
     } catch (error) {
       if (error instanceof AxiosError) {

--- a/frontend/models/plant.types.ts
+++ b/frontend/models/plant.types.ts
@@ -323,7 +323,10 @@ export interface PlantaUsuario {
     id: number;
     url_blob: string;
     nombre_archivo: string;
+    organ?: string;
+    tamano_bytes: number;
   };
+  imagenes_identificacion?: ImagenIdentificacionResponse[];
 }
 
 /**


### PR DESCRIPTION
- Nuevo endpoint GET /api/plantas/con-imagenes que retorna plantas con todas sus imágenes
- Componente PlantImageCarousel con auto-rotación cada 4 segundos
- Indicadores de carousel y contador de fotos en badges
- Schema PlantaUsuarioResponse con arrays de imágenes
- Servicio obtener_plantas_usuario_con_imagenes() en backend
- Soporte para imagenes_identificacion en tipos de frontend
- Organización por órgano de planta (leaf, flower, fruit, etc)

Relacionado: Dashboard T-023