### PR TITLE
feat: Agregar selección de imágenes previas en análisis de salud (#87)

### DIFF
--- a/frontend/lib/image.service.ts
+++ b/frontend/lib/image.service.ts
@@ -125,6 +125,55 @@ class ImageService {
   }
 
   /**
+   * Obtiene todas las imágenes asociadas a una planta específica
+   * 
+   * @param plantaId - ID de la planta
+   * @returns Promise con la lista de imágenes de la planta
+   * @throws Error si no se pueden obtener las imágenes
+   */
+  async obtenerImagenesPlanta(plantaId: number): Promise<{
+    id: number
+    nombre_archivo: string
+    url_blob: string
+    organ?: string
+    tamano_bytes: number
+  }[]> {
+    try {
+      const response = await axiosInstance.get<{
+        imagenes: Array<{
+          id: number
+          usuario_id: number
+          nombre_archivo: string
+          nombre_blob: string
+          url_blob: string
+          container_name: string
+          content_type: string
+          tamano_bytes: number
+          descripcion?: string
+          organ?: string
+          created_at: string
+          updated_at: string
+          is_deleted: boolean
+        }>
+        total: number
+      }>(`${this.BASE_PATH}/planta/${plantaId}`)
+      
+      // Mapear al formato esperado
+      return response.data.imagenes.map(img => ({
+        id: img.id,
+        nombre_archivo: img.nombre_archivo,
+        url_blob: img.url_blob,
+        organ: img.organ,
+        tamano_bytes: img.tamano_bytes
+      }))
+    } catch (error) {
+      console.error('Error al obtener imágenes de la planta:', error)
+      // No lanzar error, devolver array vacío si falla
+      return []
+    }
+  }
+
+  /**
    * Obtiene la URL completa de una imagen
    * 
    * @param rutaRelativa - Ruta relativa de la imagen


### PR DESCRIPTION
Implementa funcionalidad para seleccionar imágenes previamente subidas de una planta como input para análisis de salud con Gemini AI.

Cambios:
- Backend: Nuevo endpoint GET /api/imagenes/planta/{planta_id}
- Frontend: Nuevo método obtenerImagenesPlanta() en image.service.ts
- UI: Grid visual de imágenes previas con selección interactiva
- Badge 'Última' en imagen más reciente
- Indicador visual: 'Imagen existente' vs 'Imagen nueva'
- Responsive design (2-4 columnas)

Beneficios:
- Ahorra tiempo al usuario
- Reduce duplicación de imágenes
- Mejora eficiencia de almacenamiento
- Mejor experiencia de usuario

Relacionado con: Épica #67 - Sistema de Verificación de Salud
Azure DevOps: Task #87