### PR TITLE
feat: Rebrand a NatureTag con mejoras de UX, autenticación y actividades

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -62,8 +62,8 @@ class Configuracion(BaseSettings):
     # JWT Secret Key - DEBE ser sobrescrito en producción
     jwt_secret_key: str = "CHANGE_THIS_SECRET_KEY_IN_PRODUCTION_USE_ENV_FILE"
     jwt_algorithm: str = "HS256"
-    jwt_expiracion_minutos: int = 30  # Tiempo de expiración del token
-    jwt_refresh_expiracion_dias: int = 7  # Tiempo de expiración del refresh token
+    jwt_expiracion_minutos: int = 480  # Tiempo de expiración del token (8 horas)
+    jwt_refresh_expiracion_dias: int = 30  # Tiempo de expiración del refresh token (30 días)
     
     # Password hashing
     bcrypt_rounds: int = 12  # Número de rondas para bcrypt

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,5 @@
 """
-Aplicación principal FastAPI - Asistente Plantitas
+Aplicación principal FastAPI - NatureTag
 
 Backend API REST para el sistema de gestión y cuidado de plantas con IA.
 Implementa arquitectura MVC con FastAPI, SQLAlchemy y Pydantic.
@@ -12,7 +12,7 @@ Estructura del proyecto:
     /services - Lógica de negocio
     /utils - Utilidades y helpers
 
-Author: Equipo Plantitas
+Author: Equipo NatureTag
 Date: Octubre 2025
 Version: 0.1.0 (Sprint 1 - T-001)
 """

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -558,7 +558,7 @@ export default function DashboardPage() {
 
               {/* Texto motivacional adicional */}
               <p className="text-sm text-gray-500 pt-4">
-                Únete a miles de jardineros que cuidan mejor sus plantas con Asistente Plantitas 🌿
+                Únete a miles de jardineros que cuidan mejor sus plantas con NatureTag 🌿
               </p>
             </div>
           </div>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -10,24 +10,24 @@ import { ChatWidget } from "@/components/ChatWidget";
  */
 export const metadata: Metadata = {
   title: {
-    default: "Asistente Plantitas - Identificación y Cuidado de Plantas",
-    template: "%s | Asistente Plantitas"
+    default: "NatureTag - Identificación y Cuidado de Plantas con IA",
+    template: "%s | NatureTag"
   },
   description: "Identifica tus plantas con IA, recibe consejos personalizados de cuidado y mantén un registro de tu jardín.",
   keywords: ["plantas", "jardinería", "identificación", "IA", "cuidado de plantas", "botánica"],
-  authors: [{ name: "Equipo Asistente Plantitas" }],
-  creator: "Asistente Plantitas",
+  authors: [{ name: "Equipo NatureTag" }],
+  creator: "NatureTag",
   openGraph: {
     type: "website",
     locale: "es_ES",
-    url: "https://asistenteplantitas.com",
-    title: "Asistente Plantitas",
+    url: "https://naturetag.com",
+    title: "NatureTag",
     description: "Tu asistente personal de jardinería con IA",
-    siteName: "Asistente Plantitas",
+    siteName: "NatureTag",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Asistente Plantitas",
+    title: "NatureTag",
     description: "Tu asistente personal de jardinería con IA",
   },
   robots: {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,14 +1,56 @@
 /**
- * Página principal de Asistente Plantitas
+ * Página principal de NatureTag
  * Landing page con información general y acceso a la aplicación
+ * 
+ * Redirige automáticamente al dashboard si el usuario ya está autenticado
  */
 
+"use client"
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Leaf, Camera, MessageSquare, ShoppingBag } from "lucide-react";
+import { Leaf, Camera, MessageSquare, ShoppingBag, Loader2 } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
 
 export default function HomePage() {
+  const { estaAutenticado, estaCargando } = useAuth();
+  const router = useRouter();
+
+  // Redirigir al dashboard si ya está autenticado
+  useEffect(() => {
+    if (!estaCargando && estaAutenticado) {
+      console.log("✅ Usuario ya autenticado, redirigiendo al dashboard...");
+      router.push("/dashboard");
+    }
+  }, [estaAutenticado, estaCargando, router]);
+
+  // Mostrar loader mientras verifica la sesión
+  if (estaCargando) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <Loader2 className="w-8 h-8 animate-spin mx-auto text-primary" />
+          <p className="text-muted-foreground">Verificando sesión...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Si está autenticado, no mostrar la landing (el useEffect redirigirá)
+  if (estaAutenticado) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <Loader2 className="w-8 h-8 animate-spin mx-auto text-primary" />
+          <p className="text-muted-foreground">Redirigiendo al dashboard...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen flex-col w-full">
       {/* Header */}
@@ -16,7 +58,7 @@ export default function HomePage() {
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 flex h-16 items-center justify-between max-w-7xl">
           <div className="flex items-center gap-2">
             <Leaf className="h-6 w-6 text-primary" />
-            <span className="text-xl font-bold">Asistente Plantitas</span>
+            <span className="text-xl font-bold">NatureTag</span>
           </div>
           <nav className="flex items-center gap-4">
             <Link href="/login">
@@ -99,7 +141,7 @@ export default function HomePage() {
             ¿Listo para comenzar?
           </h2>
           <p className="max-w-[85%] leading-normal text-muted-foreground sm:text-lg sm:leading-7">
-            Únete a miles de jardineros que ya usan Asistente Plantitas para cuidar
+            Únete a miles de jardineros que ya usan NatureTag para cuidar
             mejor de sus plantas.
           </p>
           <Link href="/login?mode=register">
@@ -116,7 +158,7 @@ export default function HomePage() {
           <div className="flex items-center gap-2">
             <Leaf className="h-5 w-5 text-primary" />
             <p className="text-sm text-muted-foreground">
-              © 2025 Asistente Plantitas. Todos los derechos reservados.
+              © 2025 NatureTag. Todos los derechos reservados.
             </p>
           </div>
           <div className="flex gap-4">

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -86,21 +86,22 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [])
 
   /**
-   * Configura renovación automática de tokens cada 25 minutos
-   * (los tokens expiran en 30 minutos, renovamos 5 minutos antes)
+   * Configura renovación automática de tokens cada 4 horas
+   * (los tokens expiran en 8 horas, renovamos 4 horas antes por seguridad)
    */
   useEffect(() => {
     if (!usuario) return
 
     const intervalo = setInterval(async () => {
       try {
+        console.log('🔄 Renovando token automáticamente...')
         await renovarToken()
+        console.log('✅ Token renovado exitosamente')
       } catch (error) {
-        console.error('Error al renovar token automáticamente:', error)
-        // Si falla la renovación, cerrar sesión
-        await cerrarSesion()
+        console.error('❌ Error al renovar token automáticamente:', error)
+        // No cerrar sesión inmediatamente, el interceptor de axios lo manejará
       }
-    }, 25 * 60 * 1000) // 25 minutos
+    }, 4 * 60 * 60 * 1000) // 4 horas
 
     return () => clearInterval(intervalo)
   }, [usuario])

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "proyecto-plantitas-frontend",
+  "name": "naturetag-frontend",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
- Cambio de marca de 'Asistente Plantitas' a 'NatureTag' en todo el proyecto
- Traducciones completas al español en página de detalle de planta
- Extensión de tokens JWT a 8 horas (480 min) y refresh a 30 días
- Mejora del intervalo de refresh automático de 25 min a 4 horas
- Implementación de redirección automática a dashboard para usuarios autenticados
- Mejora de timeline de actividades mostrando todos los eventos (riego, fertilización, análisis)
- Corrección de botón de fertilización que no registraba eventos
- Traducciones: 'Health Score' → 'Puntuación de Salud', tabs completas en español
- Auto-refresh de página después de regar o fertilizar plantas